### PR TITLE
Revert "Block Binder thread until incoming call process completes"

### DIFF
--- a/src/java/com/android/internal/telephony/imsphone/ImsPhoneCallTracker.java
+++ b/src/java/com/android/internal/telephony/imsphone/ImsPhoneCallTracker.java
@@ -138,9 +138,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
-import java.util.concurrent.CancellationException;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Executor;
@@ -321,10 +318,8 @@ public class ImsPhoneCallTracker extends CallTracker implements ImsPullCall {
 
         @Override
         public void onIncomingCall(IImsCallSession c, Bundle extras) {
-            // we want to ensure we block this binder thread until incoming call setup completes
-            // as to avoid race conditions where the ImsService tries to update the state of the
-            // call before the listeners have been attached.
-            executeAndWait(()-> processIncomingCall(c, extras));
+            TelephonyUtils.runWithCleanCallingIdentity(()-> processIncomingCall(c, extras),
+                    mExecutor);
         }
 
         @Override
@@ -337,19 +332,6 @@ public class ImsPhoneCallTracker extends CallTracker implements ImsPullCall {
                     loge("onVoiceMessageCountUpdate: null phone");
                 }
             }, mExecutor);
-        }
-
-        /**
-         * Schedule the given Runnable on mExecutor and block this thread until it finishes.
-         * @param r The Runnable to run.
-         */
-        private void executeAndWait(Runnable r) {
-            try {
-                CompletableFuture.runAsync(
-                        () -> TelephonyUtils.runWithCleanCallingIdentity(r), mExecutor).join();
-            } catch (CancellationException | CompletionException e) {
-                logw("Binder - exception: " + e.getMessage());
-            }
         }
     }
 


### PR DESCRIPTION
* Legacy IMS packages handling incoming calls in such a way that a blocked binder thread won`t allow to complete call setup, thus we have half dead incoming calls with unattached call session (caller can hear dialing tone whereas recipient got nothing)

This reverts commit 75c3dc9ba272b43971f519caba0382f9871c7d9d.

Change-Id: I55a8f3bbca4a2b9a6bc7511e9fe2d0884a8818e5